### PR TITLE
Remove Script section from readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,37 +18,6 @@ To use this repository, you need to have a Google account and access to Google C
 - To learn more about Google Colab, you can check out this [link](https://colab.research.google.com/notebooks/intro.ipynb).
 - To learn more about IPython, you can check out this [link](https://ipython.org/).
 - To learn more about google.colab, you can check out this [link](https://colab.research.google.com/notebooks/snippets/importing_libraries.ipynb).
-
-## Script :
-```
-#@title <b>Time Out Preventer (Advanced) </b></strong>
-%%capture
-AUTO_RECONNECT = True #@param {type:"boolean"}
-#@markdown **Run this code to prevent Google Colab from Timeout**
-from os import makedirs
-makedirs("/root/.config/rclone", exist_ok = True)
-if AUTO_RECONNECT:
-  import IPython
-  from google.colab import output
-
-  display(IPython.display.Javascript('''
-  function ClickConnect(){
-    btn = document.querySelector("colab-connect-button")
-    if (btn != null){
-      console.log("Click colab-connect-button"); 
-      btn.click() 
-      }
-    
-    btn = document.getElementById('ok')
-    if (btn != null){
-      console.log("Click reconnect"); 
-      btn.click() 
-      }
-    }
-    
-  setInterval(ClickConnect,60000)
-  '''))
-  ```
   
   
 ## Credits


### PR DESCRIPTION
This pull request removes a script from the `README.md` file that was previously included to prevent Google Colab from timing out. The change simplifies the documentation by eliminating this advanced feature.

Documentation simplification:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-L52): Removed the "Time Out Preventer (Advanced)" script section, which included a code snippet and related explanation for preventing Google Colab from timing out. This change reduces complexity in the documentation.